### PR TITLE
修复雷电模拟器的自启动失败问题 & 调整相关UI

### DIFF
--- a/kotonebot/backend/bot.py
+++ b/kotonebot/backend/bot.py
@@ -190,6 +190,7 @@ class KotoneBot:
             self.backend_instance = create_custom(
                 adb_ip=config.backend.adb_ip,
                 adb_port=config.backend.adb_port,
+                adb_emulator_name=config.backend.adb_emulator_name,
                 exe_path=exe
             )
             if not self.backend_instance.running():

--- a/kotonebot/client/host/custom.py
+++ b/kotonebot/client/host/custom.py
@@ -56,12 +56,12 @@ def _type_check(ins: Instance) -> CustomInstance:
         raise ValueError(f'Instance {ins} is not a CustomInstance')
     return ins
 
-def create(exe_path: str, adb_ip: str, adb_port: int) -> CustomInstance:
-    return CustomInstance(exe_path, id='custom', name='Custom', adb_ip=adb_ip, adb_port=adb_port)
+def create(exe_path: str, adb_ip: str, adb_port: int, adb_emulator_name: str) -> CustomInstance:
+    return CustomInstance(exe_path, id='custom', name='Custom', adb_ip=adb_ip, adb_port=adb_port, adb_emulator_name=adb_emulator_name)
 
 
 if __name__ == '__main__':
-    ins = create(r'C:\Program Files\BlueStacks_nxt\HD-Player.exe', '127.0.0.1', 5555)
+    ins = create(r'C:\Program Files\BlueStacks_nxt\HD-Player.exe', '127.0.0.1', 5555, '**emulator-name**')
     ins.start()
     ins.wait_available()
     input('Press Enter to stop...')

--- a/kotonebot/config/base_config.py
+++ b/kotonebot/config/base_config.py
@@ -15,6 +15,13 @@ class BackendConfig(ConfigBaseModel):
     """adb 连接的 ip 地址。"""
     adb_port: int = 5555
     """adb 连接的端口。"""
+    adb_emulator_name: str = 'emulator-5554'
+    """
+    adb 连接的模拟器名，用于 自动启动模拟器 功能。
+    
+    雷电模拟器需要设置正确的模拟器名，否则 自动启动模拟器 功能将无法正常工作。
+    其他功能不受影响。
+    """
     screenshot_impl: Literal['adb', 'adb_raw', 'uiautomator2'] = 'adb'
     """
     截图方法。暂时推荐使用【adb】截图方式。

--- a/kotonebot/ui/gr.py
+++ b/kotonebot/ui/gr.py
@@ -235,6 +235,7 @@ class KotoneBotUI:
         keep_screenshots: bool,
         check_emulator: bool,
         emulator_path: str,
+        adb_emulator_name: str,
         trace_recommend_card_detection: bool,
         purchase_enabled: bool,
         money_enabled: bool,
@@ -295,6 +296,7 @@ class KotoneBotUI:
         
         self.current_config.backend.adb_ip = adb_ip
         self.current_config.backend.adb_port = adb_port
+        self.current_config.backend.adb_emulator_name = adb_emulator_name
         self.current_config.backend.screenshot_impl = screenshot_method
         self.current_config.keep_screenshots = keep_screenshots
         self.current_config.backend.check_emulator = check_emulator
@@ -455,6 +457,63 @@ class KotoneBotUI:
                 inputs=[task_dropdown],
                 outputs=[task_result]
             )
+
+    def _create_emulator_settings(self) -> Tuple[gr.Textbox, gr.Number, gr.Dropdown, gr.Checkbox, gr.Checkbox, gr.Textbox, gr.Textbox]:
+        with gr.Column():
+            gr.Markdown("### 模拟器设置")
+            adb_ip = gr.Textbox(
+                value=self.current_config.backend.adb_ip,
+                label="ADB IP 地址",
+                info=BackendConfig.model_fields['adb_ip'].description,
+                interactive=True
+            )
+            adb_port = gr.Number(
+                value=self.current_config.backend.adb_port,
+                label="ADB 端口",
+                info=BackendConfig.model_fields['adb_port'].description,
+                minimum=1,
+                maximum=65535,
+                step=1,
+                interactive=True
+            )
+            screenshot_impl = gr.Dropdown(
+                choices=['adb', 'adb_raw', 'uiautomator2'],
+                value=self.current_config.backend.screenshot_impl,
+                label="截图方法",
+                info=BackendConfig.model_fields['screenshot_impl'].description,
+                interactive=True
+            )
+            keep_screenshots = gr.Checkbox(
+                label="保留截图数据",
+                value=self.current_config.keep_screenshots,
+                info=UserConfig.model_fields['keep_screenshots'].description,
+                interactive=True
+            )
+            check_emulator = gr.Checkbox(
+                label="检查并启动模拟器",
+                value=self.current_config.backend.check_emulator,
+                info=BackendConfig.model_fields['check_emulator'].description,
+                interactive=True
+            )
+            with gr.Group(visible=self.current_config.backend.check_emulator) as check_emulator_group:
+                emulator_path = gr.Textbox(
+                    value=self.current_config.backend.emulator_path,
+                    label="模拟器 exe 文件路径",
+                    info=BackendConfig.model_fields['emulator_path'].description,
+                    interactive=True
+                )
+                adb_emulator_name = gr.Textbox(
+                    value=self.current_config.backend.adb_emulator_name,
+                    label="ADB 模拟器名称",
+                    info=BackendConfig.model_fields['adb_emulator_name'].description,
+                    interactive=True
+                )
+            check_emulator.change(
+                fn=lambda x: gr.Group(visible=x),
+                inputs=[check_emulator],
+                outputs=[check_emulator_group]
+            )
+        return adb_ip, adb_port, screenshot_impl, keep_screenshots, check_emulator, emulator_path, adb_emulator_name
 
     def _create_purchase_settings(self) -> Tuple[gr.Checkbox, gr.Checkbox, gr.Checkbox, gr.Dropdown, gr.Dropdown]:
         with gr.Column():
@@ -820,48 +879,7 @@ class KotoneBotUI:
             gr.Markdown("## 设置")
             
             # 模拟器设置
-            with gr.Column():
-                gr.Markdown("### 模拟器设置")
-                adb_ip = gr.Textbox(
-                    value=self.current_config.backend.adb_ip,
-                    label="ADB IP 地址",
-                    info=BackendConfig.model_fields['adb_ip'].description,
-                    interactive=True
-                )
-                adb_port = gr.Number(
-                    value=self.current_config.backend.adb_port,
-                    label="ADB 端口",
-                    info=BackendConfig.model_fields['adb_port'].description,
-                    minimum=1,
-                    maximum=65535,
-                    step=1,
-                    interactive=True
-                )
-                screenshot_impl = gr.Dropdown(
-                    choices=['adb', 'adb_raw', 'uiautomator2'],
-                    value=self.current_config.backend.screenshot_impl,
-                    label="截图方法",
-                    info=BackendConfig.model_fields['screenshot_impl'].description,
-                    interactive=True
-                )
-                keep_screenshots = gr.Checkbox(
-                    label="保留截图数据",
-                    value=self.current_config.keep_screenshots,
-                    info=UserConfig.model_fields['keep_screenshots'].description,
-                    interactive=True
-                )
-                check_emulator = gr.Checkbox(
-                    label="检查并启动模拟器",
-                    value=self.current_config.backend.check_emulator,
-                    info=BackendConfig.model_fields['check_emulator'].description,
-                    interactive=True
-                )
-                emulator_path = gr.Textbox(
-                    value=self.current_config.backend.emulator_path,
-                    label="模拟器 exe 文件路径",
-                    info=BackendConfig.model_fields['emulator_path'].description,
-                    interactive=True
-                )
+            emulator_settings = self._create_emulator_settings()
             
             # 商店购买设置
             purchase_settings = self._create_purchase_settings()
@@ -935,8 +953,7 @@ class KotoneBotUI:
             
             # 收集所有设置组件
             all_settings = [
-                adb_ip, adb_port, screenshot_impl, keep_screenshots,
-                check_emulator, emulator_path,
+                *emulator_settings,
                 trace_recommend_card_detection,
                 *purchase_settings,
                 activity_funds,


### PR DESCRIPTION
雷电模拟器，自启动时，会卡在 `[DEBUG][kotonebot.client.host.protocol] Getting device list...`。经排查，是因为devices设备列表中的设备名称为 `emulator-5554`，而非 `127.0.0.1:5555`。
```
[2025-03-16 10:55:27,167][DEBUG][kotonebot.client.host.protocol] Getting device list...
[2025-03-16 10:55:27,177][DEBUG][kotonebot.client.host.protocol] Get device list success. devices=[AdbDevice(serial=emulator-5554)]
```

我在ui中添加了一个新的config项，对emulator-5554进行配置，检测时同时检测两种情况（emulator_name 和 host）。修改后，雷电模拟器可以正常自启动。

修复后的完整日志：
```
[2025-03-16 11:00:57,575][INFO][kotonebot.backend.bot] Checking backend...
[2025-03-16 11:00:57,938][INFO][kotonebot.backend.bot] Starting custom backend...
[2025-03-16 11:00:57,939][INFO][kotonebot.client.host.custom] Starting process "E:\Programs\leidian\LDPlayerVK\dnplayer.exe"...
[2025-03-16 11:00:57,958][INFO][kotonebot.backend.bot] Waiting for custom backend to be available...
[2025-03-16 11:00:57,958][INFO][kotonebot.client.host.protocol] Starting to wait for emulator Custom(127.0.0.1:5555) to be available...
[2025-03-16 11:00:58,960][DEBUG][kotonebot.client.host.protocol] Ping emulator Custom(127.0.0.1:5555)...
[2025-03-16 11:00:58,960][DEBUG][kotonebot.client.host.protocol] TCP ping 127.0.0.1:5555...
[2025-03-16 11:00:59,462][DEBUG][kotonebot.client.host.protocol] TCP ping 127.0.0.1:5555 success.
[2025-03-16 11:00:59,463][DEBUG][kotonebot.client.host.protocol] Ping emulator Custom(127.0.0.1:5555) success.
[2025-03-16 11:00:59,962][DEBUG][kotonebot.client.host.protocol] Connecting to emulator Custom(127.0.0.1:5555)...
[2025-03-16 11:01:00,963][DEBUG][kotonebot.client.host.protocol] Connecting to emulator Custom(127.0.0.1:5555)...
[2025-03-16 11:01:00,964][DEBUG][kotonebot.client.host.protocol] Connect to emulator Custom(127.0.0.1:5555) success.
[2025-03-16 11:01:01,966][DEBUG][kotonebot.client.host.protocol] Getting device list...
[2025-03-16 11:01:02,967][DEBUG][kotonebot.client.host.protocol] Getting device list...
[2025-03-16 11:01:03,968][DEBUG][kotonebot.client.host.protocol] Getting device list...
[2025-03-16 11:01:04,969][DEBUG][kotonebot.client.host.protocol] Getting device list...
[2025-03-16 11:01:05,970][DEBUG][kotonebot.client.host.protocol] Getting device list...
[2025-03-16 11:01:05,971][DEBUG][kotonebot.client.host.protocol] Get device list success. devices=[AdbDevice(serial=emulator-5554)]
[2025-03-16 11:01:05,971][DEBUG][kotonebot.client.host.protocol] Get target device success. d=AdbDevice(serial=emulator-5554)
[2025-03-16 11:01:06,971][DEBUG][kotonebot.client.host.protocol] Waiting for device state...
[2025-03-16 11:01:06,972][DEBUG][kotonebot.client.host.protocol] Device state ready. state=device
[2025-03-16 11:01:07,974][DEBUG][kotonebot.client.host.protocol] Waiting for device boot completed...
[2025-03-16 11:01:07,989][DEBUG][kotonebot.client.host.protocol] Device boot completed. ret=1
[2025-03-16 11:01:08,989][DEBUG][kotonebot.client.host.protocol] Waiting for launcher... (current=RunningAppInfo(package='com.android.launcher3', activity='com.android.launcher3.Launcher', pid=0))
[2025-03-16 11:01:08,989][INFO][kotonebot.client.host.protocol] Emulator Custom(127.0.0.1:5555) now is available.
[2025-03-16 11:01:10,978][INFO][kotonebot.client.host.protocol] Emulator Custom(127.0.0.1:5555) now is available.
```