### PR TITLE
fix(task): 修复了自动扭蛋功能，无法正常增加期望扭蛋数的问题

### DIFF
--- a/kotonebot/tasks/capsule_toys.py
+++ b/kotonebot/tasks/capsule_toys.py
@@ -30,16 +30,17 @@ def draw_capsule_toys(button: TemplateMatchResult, times: int):
     )
     sleep(0.5)
 
+    add_button = image.expect_wait(R.Daily.ButtonShopCountAdd, timeout=5)
+    for _ in range(times):
+        device.click(add_button)
+    sleep(0.5)
+
     confirm_button = image.find(R.Common.ButtonConfirm, colored=True)
     if confirm_button is None:
         # 硬币不足
         logger.info('Not enough coins.')
     else:
         # 硬币足够
-        add_button = image.expect_wait(R.Daily.ButtonShopCountAdd, timeout=5)
-        for _ in range(times):
-            device.click(add_button)
-        sleep(0.5)
         device.click(confirm_button)
         sleep(0.5)
     


### PR DESCRIPTION
睡前看到qq频道有人说，然后就来修了下。

推测的bug原因：应该是版本更新导致的bug。在之前的版本，硬币数量如果是0，“决定”按钮也是亮的，所以模式匹配可以匹配上；新版本，硬币数量为0时，“决定”按钮是灰色的，所以识别失败。在目前的逻辑下，就会出问题。

这里更新了一下扭蛋的逻辑。