### PR TITLE
fix(task): 修复了系统占用过高时，点击'跳过比赛按钮'失败的问题

### DIFF
--- a/kotonebot/tasks/daily/contest.py
+++ b/kotonebot/tasks/daily/contest.py
@@ -90,9 +90,8 @@ def pick_and_contest(has_ongoing_contest: bool = False) -> bool:
         device.click()
         sleep(0.5)
     # 点击 SKIP
-    sleep(3)
     logger.debug('Clicking on SKIP.')
-    device.click(image.expect(R.Daily.ButtonIconSkip, preprocessors=[WhiteFilter()]))
+    device.click(image.expect_wait(R.Daily.ButtonIconSkip, timeout=10, preprocessors=[WhiteFilter()]))
     while not image.wait_for(R.Common.ButtonNextNoIcon, timeout=2):
         device.click_center()
         logger.debug('Waiting for the result.')


### PR DESCRIPTION
竞赛skip按钮这里逻辑有点问题，加载慢时会点击不到skip按钮。（例如我机器同时跑学偶&鸣潮的时候）