### PR TITLE
fix(task): 修复了kuyo延迟弹出广告，导致识别错误的问题

### DIFF
--- a/kotonebot/tasks/start_game.py
+++ b/kotonebot/tasks/start_game.py
@@ -9,7 +9,7 @@ from kotonebot.util import Countdown, Interval
 from .actions.scenes import at_home, goto_home
 from .actions.commu import handle_unread_commu
 from kotonebot.errors import GameUpdateNeededError
-from kotonebot import task, action, device, image, ocr
+from kotonebot import task, action, sleep, device, image, ocr
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +84,8 @@ def android_launch():
         device.launch_app('org.kuyo.game')
         # 点击"加速"
         device.click(image.expect_wait(R.Kuyo.ButtonTab3Speedup, timeout=10))
+        # Kuyo会延迟加入广告，导致识别后，原位置突然弹出广告，导致进入广告页面
+        sleep(2)
         # 点击"K空间启动"
         device.click(image.expect_wait(R.Kuyo.ButtonStartGame, timeout=10))
 


### PR DESCRIPTION
kuyo启动游戏页面，广告会延迟加载。导致可能会出这种情况：按键识别后，广告突然加载，导致按键位置变换，并且错误地点击了广告按钮。

这个pr在此页面延迟了2s，避免点击广告。