### PR TITLE
fix(task): 修复了进入商店时，错误进入交换所的问题

### DIFF
--- a/kotonebot/kaa/tasks/actions/scenes.py
+++ b/kotonebot/kaa/tasks/actions/scenes.py
@@ -72,6 +72,7 @@ def goto_shop():
             break
         elif image.find(R.Daily.ButtonShop):
             device.click()
+            sleep(0.5)
         # 可以设置默认购买数量为 MAX 的提示框
         elif image.find(R.Daily.TextDefaultExchangeCountChangeDialog):
             dialog.yes()


### PR DESCRIPTION
fix: #36 

错误进入的原因是连续点了两次商店。机器性能比较好的情况下，就会出现这种情况。验证的日志如下：
<img width="754" height="503" alt="577a861d709ee10f21d6e5188b11c765" src="https://github.com/user-attachments/assets/7b4791d2-333f-45d5-a982-e7bb1248cb9d" />
<img width="917" height="357" alt="1ffbaa20e3904b029e74b471b1340d1b" src="https://github.com/user-attachments/assets/05aa0825-a691-4027-93d8-af1f203c83c6" />