### PR TITLE
feat(ui): 在'状态'页新增了全选、全不选、只选培育、只不选培育这四个新按键

### DIFF
--- a/kotonebot/kaa/main/gr.py
+++ b/kotonebot/kaa/main/gr.py
@@ -2369,8 +2369,11 @@ class KotoneBotUI:
             # 社团奖励设置
             club_reward_settings = self._create_club_reward_settings()
 
-            # 升级支援卡设置
+            # 扭蛋设置
             capsule_toys_settings = self._create_capsule_toys_settings()
+
+            # 升级支援卡设置
+            upgrade_support_card_settings = self._create_upgrade_support_card_settings()
 
             # 启动游戏设置
             start_game_settings = self._create_start_game_settings()
@@ -2402,6 +2405,7 @@ class KotoneBotUI:
                 mission_reward_settings,
                 club_reward_settings,
                 capsule_toys_settings,
+                upgrade_support_card_settings,
                 start_game_settings,
                 end_game_settings,
                 misc_settings,


### PR DESCRIPTION
写了一个很方便的功能，这样基本上就可以取代掉"任务"页的功能了。

不然之前平常刷每日和刷活动，就需要频繁地在两个页面之间来回切换，同时还要手动管理“培育”的激活状态。

然后这个pr还给详细设置页面补了丢失的“升级支援卡”设置233

<img width="860" height="538" alt="image" src="https://github.com/user-attachments/assets/053afc01-bfc8-4ebf-8627-1f5687f79549" />

代码实现上的话，稍微关键的改动是把checkbox回调函数从change改为了input，避免在全选时反复触发checkbox的回调函数。

<img width="835" height="521" alt="image" src="https://github.com/user-attachments/assets/68499914-44b2-4228-851e-816e7d164455" />

<img width="943" height="200" alt="image" src="https://github.com/user-attachments/assets/f49dcd99-d3fe-4fc3-85d0-b63358729a05" />

